### PR TITLE
fix autoincrement

### DIFF
--- a/sqflite/lib/src/compose/create.dart
+++ b/sqflite/lib/src/compose/create.dart
@@ -9,7 +9,7 @@ String composeCreateColumn(final CreateColumn col) {
       if (!col.isPrimaryKey)
         throw new Exception(
             'SQLite requires that AUTOINCREMENT columns are Primary keys!');
-      sb.write(' INTEGER PRIMARY KEY AUTOINCREMENT');
+      sb.write(' INTEGER PRIMARY KEY');
     } else {
       sb.write(' INT');
     }


### PR DESCRIPTION
Autoincrement is not really well seen apparently, and by default a INTEGER PRIMARY KEY already auto increment itself.

```
The AUTOINCREMENT keyword imposes extra CPU, memory, disk space, and disk I/O overhead and should be avoided if not strictly needed. It is usually not needed.
```
cf https://www.sqlite.org/autoinc.html and https://stackoverflow.com/a/50753627/541867