### PR TITLE
add switch database method sqflite adapter

### DIFF
--- a/sqflite/lib/src/adapter.dart
+++ b/sqflite/lib/src/adapter.dart
@@ -30,22 +30,14 @@ class SqfliteAdapter implements Adapter<sqf.Database> {
   }
 
   /// Closes all connections to the database.
-  Future<void> close() => _connection.close();
-
-  /// Change connection to the database.
-  Future<void> switchDatabase(sqf.Database connection) async {
-    if (_connection != null && _connection.isOpen) {
-      await _connection.close();
-    }
-    _connection = connection;
-  }
+  Future<void> close() => connection.close();
 
   sqf.Database get connection => _connection;
 
   /// Finds one record in the table
   Future<Map> findOne(Find st) async {
     String stStr = composeFind(st);
-    List<Map<String, dynamic>> list = await _connection.rawQuery(stStr);
+    List<Map<String, dynamic>> list = await connection.rawQuery(stStr);
 
     if (list.length == 0) return null;
 
@@ -55,27 +47,27 @@ class SqfliteAdapter implements Adapter<sqf.Database> {
   // Finds many records in the table
   Future<List<Map>> find(Find st) async {
     String stStr = composeFind(st);
-    return _connection.rawQuery(stStr);
+    return connection.rawQuery(stStr);
   }
 
   /// Inserts a record into the table
   Future<T> insert<T>(Insert st) async {
     String strSt = composeInsert(st);
-    return _connection.rawInsert(strSt) as Future<T>;
+    return connection.rawInsert(strSt) as Future<T>;
   }
 
   /// Inserts or update a record into the table
   Future<T> upsert<T>(Upsert st) async {
     String strSt = composeUpsert(st);
-    return _connection.rawInsert(strSt) as Future<T>;
+    return connection.rawInsert(strSt) as Future<T>;
   }
 
   /// Inserts or update records into the table
   Future<void> upsertMany<T>(UpsertMany st) async {
     List<String> strSt = composeUpsertMany(st);
-    final batch = _connection.batch();
+    final batch = connection.batch();
     for (var query in strSt) {
-      _connection.execute(query);
+      connection.execute(query);
     }
     return batch.commit(noResult: true);
   }
@@ -83,21 +75,21 @@ class SqfliteAdapter implements Adapter<sqf.Database> {
   /// Inserts many records into the table
   Future<void> insertMany<T>(InsertMany st) {
     String strSt = composeInsertMany(st);
-    return _connection.execute(strSt);
+    return connection.execute(strSt);
   }
 
   /// Updates a record in the table
   Future<int> update(Update st) {
     String strSt = composeUpdate(st);
-    return _connection.rawUpdate(strSt);
+    return connection.rawUpdate(strSt);
   }
 
   /// Updates a record in the table
   Future<void> updateMany(UpdateMany st) {
     List<String> strSt = composeUpdateMany(st);
-    final batch = _connection.batch();
+    final batch = connection.batch();
     for (var query in strSt) {
-      _connection.execute(query);
+      connection.execute(query);
     }
     return batch.commit(noResult: true);
   }
@@ -105,30 +97,30 @@ class SqfliteAdapter implements Adapter<sqf.Database> {
   /// Deletes a record from the table
   Future<int> remove(Remove st) {
     String strSt = composeRemove(st);
-    return _connection.rawDelete(strSt);
+    return connection.rawDelete(strSt);
   }
 
   /// Creates the table
   Future<void> createTable(Create statement) async {
     String strSt = composeCreate(statement);
-    await _connection.execute(strSt);
+    await connection.execute(strSt);
   }
 
   /// Create the database
   Future<void> createDatabase(CreateDb st) async {
     String strSt = composeCreateDb(st);
-    await _connection.execute(strSt);
+    await connection.execute(strSt);
   }
 
   /// Drops tables from database
   Future<void> dropTable(Drop st) async {
     String strSt = composeDrop(st);
-    await _connection.execute(strSt);
+    await connection.execute(strSt);
   }
 
   Future<void> dropDb(DropDb st) async {
     String strSt = composeDropDb(st);
-    await _connection.execute(strSt);
+    await connection.execute(strSt);
   }
 
   T parseValue<T>(dynamic v) {

--- a/sqflite/lib/src/adapter.dart
+++ b/sqflite/lib/src/adapter.dart
@@ -19,7 +19,7 @@ class SqfliteAdapter implements Adapter<sqf.Database> {
 
   SqfliteAdapter.FromConnection(sqf.Database connection)
       : _connection = connection,
-        path = connection.path,
+        path = null,
         version = null;
 
   /// Connects to the database
@@ -31,6 +31,14 @@ class SqfliteAdapter implements Adapter<sqf.Database> {
 
   /// Closes all connections to the database.
   Future<void> close() => _connection.close();
+
+  /// Change connection to the database.
+  Future<void> switchDatabase(sqf.Database connection) async {
+    if (_connection != null && _connection.isOpen) {
+      await _connection.close();
+    }
+    _connection = connection;
+  }
 
   sqf.Database get connection => _connection;
 

--- a/sqflite/pubspec.yaml
+++ b/sqflite/pubspec.yaml
@@ -4,6 +4,7 @@ version: 2.2.2
 authors:
 - Ravi Teja Gudapati <tejainece@gmail.com>
 - Kevin Segaud <segaud.kevin@gmail.com>
+- Aumard Jimmy <jimmy.aumard@gmail.com>
 homepage: https://github.com/Jaguar-dart/jaguar_orm
 documentation:
 
@@ -15,7 +16,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  sqflite: ^0.11.2
+  sqflite: ^0.12.1
   jaguar_query: ^2.2.4
 
 dev_dependencies:


### PR DESCRIPTION
Little story about this :) 

In our app we need one database per user, so each time there a login we need to switch the database to another one. Problem with the current way of working of jaguar is that the Apater is needed in every "Bean" so if we want to switch database we need to switch Adapter, meaning recreate every "Bean" that are in multiple place of the app... so it's not really doable/safe to switch the adapter as reference can be kept in other objects. Instead what we can if switch the underlying connection to a new one each time the user login. 
That why `switchDatabase` is useful 