### PR TITLE
Fix of issue #89 in https://github.com/Jaguar-dart/jaguar_orm/issues/89:

### DIFF
--- a/generator/lib/src/writer/writer.dart
+++ b/generator/lib/src/writer/writer.dart
@@ -264,9 +264,9 @@ class Writer {
           _writeln(
               'await ${p.targetBeanInstanceName}.upsert(child, cascade: cascade);');
           if (_b.modelType.compareTo(p.targetInfo.modelType) > 0) {
-            _writeln('await ${p.beanInstanceName}.attach(model, child);');
+            _writeln('await ${p.beanInstanceName}.attach(newModel, child);');
           } else {
-            _writeln('await ${p.beanInstanceName}.attach(child, model);');
+            _writeln('await ${p.beanInstanceName}.attach(child, newModel);');
           }
           _writeln('}');
         }
@@ -370,9 +370,9 @@ class Writer {
           _writeln(
               'await ${p.targetBeanInstanceName}.insert(child, cascade: cascade);');
           if (_b.modelType.compareTo(p.targetInfo.modelType) > 0) {
-            _writeln('await ${p.beanInstanceName}.attach(model, child);');
+            _writeln('await ${p.beanInstanceName}.attach(newModel, child);');
           } else {
-            _writeln('await ${p.beanInstanceName}.attach(child, model);');
+            _writeln('await ${p.beanInstanceName}.attach(child, newModel);');
           }
           _writeln('}');
         }


### PR DESCRIPTION
In case of ManyToMany relation, writer.dart have written cascade functionality for insert and upsert statements. However it was generating code that have used incorrect variable.

model, which is input parameter don't have to have id, in case if it is insert of new entity with autogenerated PrimaryKey.