### PR TITLE
Fix of issue #99 in https://github.com/Jaguar-dart/jaguar_orm/issues/99:

### DIFF
--- a/generator/lib/src/writer/writer.dart
+++ b/generator/lib/src/writer/writer.dart
@@ -927,6 +927,7 @@ class Writer {
     _write('final dels = await findBy${_cap(m.modelName)}(');
     _write(m.foreignFields.map((f) => 'model.' + f.field).join(', '));
     _writeln(');');
+    _writeln('if(dels.isNotEmpty) {');
     _write('await removeBy${_cap(m.modelName)}(');
     _write(m.foreignFields.map((f) => 'model.' + f.field).join(', '));
     _writeln(');');
@@ -947,6 +948,8 @@ class Writer {
     _writeln('}');
 
     _write('return await $beanName.removeWhere(exp);');
+    _writeln('}');
+    _writeln('return 0;');
     _writeln('}');
   }
 


### PR DESCRIPTION
In case of optional ManyToMany relation,remove with cascade would fail if there were no entities in relation.

Wrapping deletion of pivot entities in if fixes this issue by not executing unnecessary delete statement.