### PR TITLE
Fix foreign keys generation to use the right column name in database and not the field name

### DIFF
--- a/generator/lib/src/writer/writer.dart
+++ b/generator/lib/src/writer/writer.dart
@@ -126,7 +126,7 @@ class Writer {
         final foreign = f.foreign;
         if (foreign is BelongsToForeign) {
           _write(', foreignTable: ${foreign.beanInstanceName}.tableName');
-          _write(", foreignCol: '${foreign.refCol}'");
+          _write(", foreignCol: ${foreign.beanInstanceName}.${foreign.refCol}.name");
         } else {
           throw Exception('Unimplemented!');
         }


### PR DESCRIPTION
fix https://github.com/Jaguar-dart/jaguar_orm/issues/158

This is a fix for v3, I guess v4 have this bug too but code as changed too much for me to also do the change here.

I would appreciate to have this deployed asap as it's quite a critical bug as the all relation in database are wrong