### PR TITLE
Update the literal class names.

### DIFF
--- a/query/lib/src/core/statement/upsert.dart
+++ b/query/lib/src/core/statement/upsert.dart
@@ -52,27 +52,27 @@ class Upsert implements Statement {
 
   /// Convenience method to set the [value] of int [column].
   Upsert setInt(/* String | I */ column, int value) {
-    return set(column, IntLiteral(value));
+    return set(column, IntL(value));
   }
 
   /// Convenience method to set the [value] of string [column].
   Upsert setString(/* String | I */ column, String value) {
-    return set(column, StrLiteral(value));
+    return set(column, StrL(value));
   }
 
   /// Convenience method to set the [value] of bool [column].
   Upsert setBool(/* String | I */ column, bool value) {
-    return set(column, BoolLiteral(value));
+    return set(column, BoolL(value));
   }
 
   /// Convenience method to set the [value] of date time [column].
   Upsert setTimestamp(/* String | I */ column, DateTime value) {
-    return set(column, TimestampLiteral(value));
+    return set(column, TimestampL(value));
   }
 
   /// Convenience method to set the [value] of date time [column].
   Upsert setDuration(/* String | I */ column, Duration value) {
-    return set(column, DurationLiteral(value));
+    return set(column, DurationL(value));
   }
 
   /// Executes the statement with the given connection.


### PR DESCRIPTION
Literal class names are shortened in the `core/expression/literal.dart` file, but the changes are not applied in this file. So `build_runner` gives an error when trying to generate files.